### PR TITLE
use unique serial number in USB descriptor

### DIFF
--- a/firmware/foxdac/CMakeLists.txt
+++ b/firmware/foxdac/CMakeLists.txt
@@ -30,6 +30,6 @@ if (TARGET usb_device)
             PICO_DEFAULT_UART_TX_PIN=16
     )
 
-    target_link_libraries(foxdac dac_ui dac_dsp ssd1306_driver wm8805 tpa6130 pico_stdlib usb_device pico_audio_spdif pico_multicore hardware_i2c)
+    target_link_libraries(foxdac dac_ui dac_dsp ssd1306_driver wm8805 tpa6130 pico_stdlib usb_device pico_audio_spdif pico_multicore hardware_i2c pico_unique_id)
     pico_add_extra_outputs(foxdac)
 endif()

--- a/firmware/foxdac/usb_spdif.c
+++ b/firmware/foxdac/usb_spdif.c
@@ -12,6 +12,7 @@
 #include "pico/audio.h"
 #include "pico/audio_spdif.h"
 #include "pico/multicore.h"
+#include "pico/unique_id.h"
 #include "hardware/sync.h"
 #include "hardware/irq.h"
 #include "hardware/structs/bus_ctrl.h"
@@ -36,7 +37,7 @@ static char *descriptor_strings[] =
 {
         "astanoev.com",
         "FoxDAC",
-        "0123456789AB"
+        "0123456789ABCDEF" //MUST be 16 chars
 };
 
 // todo fix these
@@ -748,6 +749,9 @@ void core0_init() {
     // Init red LED
     gpio_init(18);
     gpio_set_dir(18, GPIO_OUT);
+
+    //set serial number
+    pico_get_unique_board_id_string(descriptor_strings[2],17);
 
     // Grant high bus priority to the DMA
     bus_ctrl_hw->priority = BUSCTRL_BUS_PRIORITY_DMA_W_BITS | BUSCTRL_BUS_PRIORITY_DMA_R_BITS;


### PR DESCRIPTION
could probably solve some problems with mor than one DAC connected to the same PC

-- NOT YET TESTED --